### PR TITLE
Add FastAPI API for prediction model

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,30 @@ python prediction_model.py
 This command reads `data/raw/Competition_Data.csv`, trains the model, and saves
 the resulting pipeline to `model.pkl`.
 
+## API
+
+Serve the trained model through a FastAPI application.
+
+1. Install the API dependencies:
+   ```bash
+   pip install fastapi uvicorn joblib pandas scikit-learn
+   ```
+2. Ensure `model.pkl` exists by running:
+   ```bash
+   python prediction_model.py
+   ```
+3. Start the API with:
+   ```bash
+   uvicorn api:app --reload
+   ```
+   The server will be available at `http://127.0.0.1:8000`.
+4. Send a POST request to `/predict` with JSON containing the following fields:
+   - `Store_ID`
+   - `Item_ID`
+   - `Price`
+   - `Item_Quantity`
+   - `Competition_Price`
+
 ## Contact
 
 For questions or collaboration, please contact Julio.

--- a/api.py
+++ b/api.py
@@ -1,0 +1,25 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import joblib
+import pandas as pd
+
+class PredictionInput(BaseModel):
+    Store_ID: str
+    Item_ID: str
+    Price: float
+    Item_Quantity: int
+    Competition_Price: float
+
+app = FastAPI(title="Price Optimization API")
+
+# Load model and preprocessor on startup
+model_bundle = joblib.load("model.pkl")
+model = model_bundle["model"]
+preprocessor = model_bundle["preprocessor"]
+
+@app.post("/predict")
+def predict(data: PredictionInput):
+    df = pd.DataFrame([data.dict()])
+    processed = preprocessor.transform(df)
+    prediction = model.predict(processed)[0]
+    return {"prediction": prediction}


### PR DESCRIPTION
## Summary
- create `api.py` to serve the model with FastAPI
- document how to run the API in `README.md`

## Testing
- `python -m py_compile api.py prediction_model.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bb84113908326a0453fc9b9fe3e87